### PR TITLE
Fix: Update LinkedIn profile link and remove social metadata

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -30,7 +30,7 @@ export default function Footer() {
 
         <div className="flex items-center space-x-6 mb-4 md:mb-0">
           <a
-            href="https://linkedin.com/in/scottcullum"
+            href="https://linkedin.com/in/scullum"
             target="_blank"
             rel="noopener noreferrer"
             className="text-[var(--foreground)] hover:text-accent transition-colors duration-200 flex items-center"

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -33,7 +33,7 @@ export const baseMetadata: Metadata = {
     title: 'Scott M. Cullum | Creative Technologist & Strategist',
     description: 'Scott M. Cullum is a creative technologist and strategist with 20+ years of experience in design, engineering, and leadership.',
     images: ['/og-image.jpg'], // Same as OpenGraph image
-    creator: '@scottcullum' // Replace with your Twitter handle if you have one
+    creator: '@scullum' // Twitter handle matching LinkedIn profile
   }
 }
 

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -28,13 +28,7 @@ export const baseMetadata: Metadata = {
       }
     ]
   },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Scott M. Cullum | Creative Technologist & Strategist',
-    description: 'Scott M. Cullum is a creative technologist and strategist with 20+ years of experience in design, engineering, and leadership.',
-    images: ['/og-image.jpg'], // Same as OpenGraph image
-    creator: '@scullum' // Twitter handle matching LinkedIn profile
-  }
+  // No Twitter metadata
 }
 
 // Helper to generate metadata for specific pages


### PR DESCRIPTION
This PR updates the LinkedIn profile link to use 'scullum' instead of 'scottcullum' and ensures consistent references to Scott M. Cullum throughout the site. It also removes unnecessary social metadata.